### PR TITLE
Minor cleanup based on my DPoP review

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jws/JWSHeader.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSHeader.java
@@ -57,12 +57,6 @@ public class JWSHeader implements JOSEHeader {
         this.contentType = contentType;
     }
 
-    public JWSHeader(Algorithm algorithm, String type, String contentType, String keyId) {
-        this.algorithm = algorithm;
-        this.type = type;
-        this.keyId = keyId;
-    }
-
     public JWSHeader(Algorithm algorithm, String type, String keyId, JWK key) {
         this.algorithm = algorithm;
         this.type = type;

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -46,8 +46,6 @@ public final class OIDCConfigAttributes {
     public static final String USE_MTLS_HOK_TOKEN = "tls.client.certificate.bound.access.tokens";
 
     public static final String DPOP_BOUND_ACCESS_TOKENS = "dpop.bound.access.tokens";
-    public static final String DPOP_PROOF_LIFETIME = "dpop.proof.lifetime";
-    public static final String DPOP_ALLOWED_CLOCK_SKEW = "dpop.allowed.clock.skew";
 
     public static final String ID_TOKEN_SIGNED_RESPONSE_ALG = "id.token.signed.response.alg";
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -498,8 +498,8 @@ public class TokenManager {
             }
 
             if (Profile.isFeatureEnabled(Profile.Feature.DPOP)) {
-                if (OIDCAdvancedConfigWrapper.fromClientModel(client).isUseDPoP() && (client.isPublicClient() || client.isBearerOnly())) {
-                    DPoP dPoP = (DPoP) session.getAttribute("dpop");
+                if (OIDCAdvancedConfigWrapper.fromClientModel(client).isUseDPoP() && client.isPublicClient()) {
+                    DPoP dPoP = (DPoP) session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE);
                     try {
                         DPoPUtil.validateBinding(refreshToken, dPoP);
                     } catch (VerificationException ex) {
@@ -1016,6 +1016,7 @@ public class TokenManager {
         AccessToken accessToken;
         RefreshToken refreshToken;
         IDToken idToken;
+        String responseTokenType;
 
         boolean generateAccessTokenHash = false;
         String codeHash;
@@ -1030,6 +1031,7 @@ public class TokenManager {
             this.session = session;
             this.userSession = userSession;
             this.clientSessionCtx = clientSessionCtx;
+            this.responseTokenType = formatTokenType(client);
         }
 
         public AccessToken getAccessToken() {
@@ -1050,6 +1052,11 @@ public class TokenManager {
         }
         public AccessTokenResponseBuilder refreshToken(RefreshToken refreshToken) {
             this.refreshToken = refreshToken;
+            return this;
+        }
+
+        public AccessTokenResponseBuilder responseTokenType(String responseTokenType) {
+            this.responseTokenType = responseTokenType;
             return this;
         }
 
@@ -1174,7 +1181,7 @@ public class TokenManager {
             if (accessToken != null) {
                 String encodedToken = session.tokens().encode(accessToken);
                 res.setToken(encodedToken);
-                res.setTokenType(formatTokenType(client));
+                res.setTokenType(responseTokenType);
                 res.setSessionState(accessToken.getSessionState());
                 if (accessToken.getExpiration() != 0) {
                     res.setExpiresIn(accessToken.getExpiration() - Time.currentTime());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -490,7 +490,7 @@ public class TokenEndpoint {
         }
 
         checkAndBindMtlsHoKToken(responseBuilder, useRefreshToken);
-        checkAndBindDPoPToken(responseBuilder, useRefreshToken && (client.isPublicClient() || client.isBearerOnly()), Profile.isFeatureEnabled(Profile.Feature.DPOP));
+        checkAndBindDPoPToken(responseBuilder, useRefreshToken && client.isPublicClient(), Profile.isFeatureEnabled(Profile.Feature.DPOP));
 
         if (TokenUtil.isOIDCRequest(scopeParam)) {
             responseBuilder.generateIDToken().generateAccessTokenHash();
@@ -521,10 +521,6 @@ public class TokenEndpoint {
             res = responseBuilder.build();
         }
 
-        if (clientConfig.isUseDPoP()) {
-            res.setTokenType(DPoPUtil.DPOP_TOKEN_TYPE);
-        }
-
         event.success();
 
         return cors.builder(Response.ok(res).type(MediaType.APPLICATION_JSON_TYPE)).build();
@@ -553,7 +549,11 @@ public class TokenEndpoint {
 
         if (clientConfig.isUseDPoP()) {
             DPoPUtil.bindToken(responseBuilder.getAccessToken(), dPoP);
-            // TODO do not bind refresh tokens issued to confidential clients, see 5. DPoP Access Token Request
+            // TODO Probably uncomment as the accessToken type "DPoP" will have more sense than "Bearer". It will require some changes in the introspection endpoint too...
+            // responseBuilder.getAccessToken().type(DPoPUtil.DPOP_TOKEN_TYPE);
+            responseBuilder.responseTokenType(DPoPUtil.DPOP_TOKEN_TYPE);
+
+            // Bind refresh tokens for public clients, See "Section 5. DPoP Access Token Request" from DPoP specification
             if (useRefreshToken) {
                 DPoPUtil.bindToken(responseBuilder.getRefreshToken(), dPoP);
             }
@@ -592,11 +592,6 @@ public class TokenEndpoint {
                 AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
                 updateClientSession(clientSession);
                 updateUserSessionFromClientAuth(userSession);
-            }
-
-            // KEYCLOAK-15169 OAuth 2.0 Demonstrating Proof-of-Possession at the Application Layer (DPoP)
-            if (clientConfig.isUseDPoP()) {
-                res.setTokenType(DPoPUtil.DPOP_TOKEN_TYPE);
             }
         } catch (OAuthErrorException e) {
             logger.trace(e.getMessage(), e);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/LogoutTokenUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/LogoutTokenUtil.java
@@ -1,6 +1,5 @@
 package org.keycloak.testsuite.util;
 
-import org.apache.http.entity.ContentType;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.JavaAlgorithm;
@@ -25,7 +24,7 @@ public class LogoutTokenUtil {
             String issuer, String clientId, String userId, String sessionId, boolean revokeOfflineSessions)
             throws IOException {
         JWSHeader jwsHeader =
-                new JWSHeader(Algorithm.RS256, OAuth2Constants.JWT, ContentType.APPLICATION_JSON.toString(), keyId);
+                new JWSHeader(Algorithm.RS256, OAuth2Constants.JWT, keyId, null);
         String logoutTokenHeaderEncoded = Base64Url.encode(JsonSerialization.writeValueAsBytes(jwsHeader));
 
         LogoutToken logoutToken = new LogoutToken();


### PR DESCRIPTION
I've did some testing and review of the DPoP PR https://github.com/keycloak/keycloak/pull/21202. I've ended doing some minor adjustements and hence sending this PR to your branch. IMO Keycloak main DPoP PR is good to go for now with those changes if you agree with them. Even if there is likely some additional follow-up work for DPoP needed.

Summary of minor changes in this commit:

- Removing one of the constructors of `JWSHeader` to simplify the code a bit

- Removing unused constants in `OIDCConfigAttributes` class

- Using refresh tokens binding for public clients as mentioned in the DPoP specification. But removing `client.isBearerOnly()` from the checks. Specification mentions only public clients, so not sure why bearerOnly clients should be included in the checks? The `bearerOnly` clients should not ever have refresh tokens anyway, so this should simplify the checks

- Adding `responseTokenType` field to `TokenManager.AccessTokenResponseBuilder`. This allows to remove some `if` conditions specific to DPoP from the `TokenEndpoint` class

- Some minor cleanup and small simplifications in the `DPoPTest` class

